### PR TITLE
fix: formatDuration rounding edge case at hour boundaries

### DIFF
--- a/__tests__/calculator.test.js
+++ b/__tests__/calculator.test.js
@@ -231,6 +231,20 @@ describe('createMaterialCalculator', () => {
         test('formats hours and minutes', () => {
             expect(calc.formatDuration(125)).toBe('2h 5min');
         });
+
+        test('does not produce 60min when rounding up near hour boundary', () => {
+            // 59.6 minutes should round to 1h 0min, not "60min"
+            expect(calc.formatDuration(59.6)).toBe('1h 0min');
+        });
+
+        test('does not produce 60min in hours+minutes format', () => {
+            // 119.6 minutes should round to 2h 0min, not "1h 60min"
+            expect(calc.formatDuration(119.6)).toBe('2h 0min');
+        });
+
+        test('formats exact hour boundary', () => {
+            expect(calc.formatDuration(60)).toBe('1h 0min');
+        });
     });
 
     // ── round ───────────────────────────────────────────────────────────

--- a/docs/shared/calculator.js
+++ b/docs/shared/calculator.js
@@ -228,8 +228,12 @@ function createMaterialCalculator() {
      */
     function formatDuration(minutes) {
         if (minutes < 1) return Math.round(minutes * 60) + 's';
-        var h = Math.floor(minutes / 60);
-        var m = Math.round(minutes % 60);
+        // Round total minutes first to avoid edge cases where
+        // Math.round(minutes % 60) = 60 (e.g. minutes = 59.6
+        // would produce "60min" instead of "1h 0min").
+        var totalMinutes = Math.round(minutes);
+        var h = Math.floor(totalMinutes / 60);
+        var m = totalMinutes % 60;
         if (h === 0) return m + 'min';
         return h + 'h ' + m + 'min';
     }


### PR DESCRIPTION
## Problem

\ormatDuration()\ in \calculator.js\ used \Math.round(minutes % 60)\ which can produce 60 at hour boundaries:
- \ormatDuration(59.6)\ → \'60min'\ (should be \'1h 0min'\)
- \ormatDuration(119.6)\ → \'1h 60min'\ (should be \'2h 0min'\)

## Fix

Round total minutes to an integer first, then compute hours and remaining minutes from the integer value. This eliminates the carry-over edge case.

## Tests

Added 3 new test cases covering boundary conditions (59.6 min, 119.6 min, exact 60 min).