### PR TITLE
fix: PrintQueue resource conflicts ignore paused jobs + throughput stack overflow

### DIFF
--- a/Try/scripts/printQueue.js
+++ b/Try/scripts/printQueue.js
@@ -130,7 +130,9 @@ class PrintQueue {
         const active = this.jobs.filter(j => j.status === STATUS.PRINTING);
         if (active.length >= this.maxConcurrent) return null;
 
-        const next = this.jobs.find(j => j.status === STATUS.QUEUED && !this._hasConflict(j, active));
+        // Paused jobs still hold their resources, so include them in conflict checks
+        const resourceHolders = this.jobs.filter(j => j.status === STATUS.PRINTING || j.status === STATUS.PAUSED);
+        const next = this.jobs.find(j => j.status === STATUS.QUEUED && !this._hasConflict(j, resourceHolders));
         if (!next) return null;
 
         next.status = STATUS.PRINTING;
@@ -194,11 +196,11 @@ class PrintQueue {
         return false;
     }
 
-    /** Get all resource conflicts for a job against currently active jobs. */
+    /** Get all resource conflicts for a job against currently active/paused jobs. */
     getConflicts(id) {
         const job = this.getJob(id);
         if (!job) return [];
-        const active = this.jobs.filter(j => j.status === STATUS.PRINTING);
+        const active = this.jobs.filter(j => j.status === STATUS.PRINTING || j.status === STATUS.PAUSED);
         const conflicts = [];
         for (const a of active) {
             const shared = job.resources.filter(r => a.resources.includes(r));
@@ -235,7 +237,7 @@ class PrintQueue {
             avgDurationMin: Math.round(avgDuration * 10) / 10,
             estimatedRemainingMin: Math.round(totalEstimated * 10) / 10,
             throughputPerHour: completed.length > 0
-                ? Math.round(completed.length / ((Date.now() - Math.min(...completed.map(j => j.startedAt))) / 3600000) * 10) / 10
+                ? Math.round(completed.length / ((Date.now() - completed.reduce((min, j) => j.startedAt < min ? j.startedAt : min, completed[0].startedAt)) / 3600000) * 10) / 10
                 : 0,
         };
     }


### PR DESCRIPTION
## Bug Fixes

### 1. Paused jobs not included in resource conflict detection
\startNext()\ and \getConflicts()\ only checked jobs with status \PRINTING\ for resource conflicts, completely ignoring \PAUSED\ jobs. A paused job still physically holds its resources (extruder, stage, crosslinker, etc.), so starting a new job requiring the same resources would cause a real-world collision.

**Fix:** Include both \PRINTING\ and \PAUSED\ jobs in conflict detection.

### 2. throughputPerHour crashes with large job histories
\getStats()\ used \Math.min(...completed.map(j => j.startedAt))\ to find the earliest start time. When \completed\ has thousands of entries, spreading into \Math.min\ exceeds the JS call stack limit, throwing a \RangeError\.

**Fix:** Replaced with a \educe\-based minimum that handles any array size.