### PR TITLE
fix: convert viability tests from IIFEs to Jest test() format

### DIFF
--- a/tests/viability.test.js
+++ b/tests/viability.test.js
@@ -29,177 +29,177 @@ function throws(fn, pattern, msg) {
 // ── Individual Damage Models ────────────────────────────────
 
 // Shear survival
-(function testShearSurvivalZero() {
+test("shear survival zero", function() {
     assert.strictEqual(est.shearSurvival(0), 1.0, 'zero shear = full survival');
-})();
+});
 
-(function testShearSurvivalNegative() {
+test("shear survival negative", function() {
     assert.strictEqual(est.shearSurvival(-10), 1.0, 'negative shear = full survival');
-})();
+});
 
-(function testShearSurvivalAtCritical() {
+test("shear survival at critical", function() {
     const s = est.shearSurvival(500);  // gammaCrit = 500
     assert.ok(s > 0 && s < 1, 'at critical shear, survival between 0 and 1');
     approx(s, Math.exp(-0.5), 0.001, 'S(γ_crit) = exp(-alpha)');
-})();
+});
 
-(function testShearSurvivalHighRate() {
+test("shear survival high rate", function() {
     const s = est.shearSurvival(2000);
     assert.ok(s < 0.01, 'very high shear rate should kill most cells');
-})();
+});
 
-(function testShearSurvivalMonotonic() {
+test("shear survival monotonic", function() {
     const s1 = est.shearSurvival(100);
     const s2 = est.shearSurvival(200);
     const s3 = est.shearSurvival(500);
     assert.ok(s1 > s2 && s2 > s3, 'shear survival decreases with rate');
-})();
+});
 
-(function testShearSurvivalCustomParams() {
+test("shear survival custom params", function() {
     const s = est.shearSurvival(100, { alpha: 1, beta: 1, gammaCrit: 100 });
     approx(s, Math.exp(-1), 0.001, 'custom params');
-})();
+});
 
 // Pressure survival
-(function testPressureSurvivalZero() {
+test("pressure survival zero", function() {
     assert.strictEqual(est.pressureSurvival(0), 1.0, 'zero pressure = full survival');
-})();
+});
 
-(function testPressureSurvivalNegative() {
+test("pressure survival negative", function() {
     assert.strictEqual(est.pressureSurvival(-50), 1.0, 'negative pressure = full survival');
-})();
+});
 
-(function testPressureSurvivalAtP50() {
+test("pressure survival at p50", function() {
     const s = est.pressureSurvival(150);  // p50 = 150
     approx(s, 0.5, 0.001, 'at p50, survival should be 0.5');
-})();
+});
 
-(function testPressureSurvivalLow() {
+test("pressure survival low", function() {
     const s = est.pressureSurvival(50);
     assert.ok(s > 0.95, 'low pressure = high survival');
-})();
+});
 
-(function testPressureSurvivalHigh() {
+test("pressure survival high", function() {
     const s = est.pressureSurvival(300);
     assert.ok(s < 0.05, 'very high pressure = low survival');
-})();
+});
 
-(function testPressureSurvivalMonotonic() {
+test("pressure survival monotonic", function() {
     const s1 = est.pressureSurvival(50);
     const s2 = est.pressureSurvival(100);
     const s3 = est.pressureSurvival(200);
     assert.ok(s1 > s2 && s2 > s3, 'pressure survival decreases monotonically');
-})();
+});
 
 // Crosslink survival
-(function testCrosslinkSurvivalZeroDuration() {
+test("crosslink survival zero duration", function() {
     assert.strictEqual(est.crosslinkSurvival(0, 50), 1.0, 'zero duration = no UV damage');
-})();
+});
 
-(function testCrosslinkSurvivalZeroIntensity() {
+test("crosslink survival zero intensity", function() {
     assert.strictEqual(est.crosslinkSurvival(5000, 0), 1.0, 'zero intensity = no UV damage');
-})();
+});
 
-(function testCrosslinkSurvivalAtEC50() {
+test("crosslink survival at e c50", function() {
     // EC50 = 15000, dose = duration * intensity
     // dose = 15000 → 50% damage → 50% survival
     const s = est.crosslinkSurvival(1500, 10);  // dose = 15000
     approx(s, 0.5, 0.001, 'at EC50 dose, survival = 0.5');
-})();
+});
 
-(function testCrosslinkSurvivalHighDose() {
+test("crosslink survival high dose", function() {
     const s = est.crosslinkSurvival(30000, 100);  // dose = 3M
     assert.ok(s < 0.01, 'massive UV dose kills nearly all cells');
-})();
+});
 
-(function testCrosslinkSurvivalModerate() {
+test("crosslink survival moderate", function() {
     const s = est.crosslinkSurvival(500, 10);  // dose = 5000
     assert.ok(s > 0.5, 'moderate dose should leave majority alive');
-})();
+});
 
 // Thermal survival
-(function testThermalOptimal() {
+test("thermal optimal", function() {
     approx(est.thermalSurvival(37), 1.0, 0.001, '37°C is optimal');
-})();
+});
 
-(function testThermalCold() {
+test("thermal cold", function() {
     const s = est.thermalSurvival(25);
     assert.ok(s < 1 && s > 0, 'cold = reduced but nonzero');
-})();
+});
 
-(function testThermalHot() {
+test("thermal hot", function() {
     const s = est.thermalSurvival(50);
     assert.ok(s < 0.5, 'very hot = significant damage');
-})();
+});
 
-(function testThermalSymmetric() {
+test("thermal symmetric", function() {
     const cold = est.thermalSurvival(32);
     const hot = est.thermalSurvival(42);
     approx(cold, hot, 0.001, 'symmetric around 37°C');
-})();
+});
 
 // Duration survival
-(function testDurationZero() {
+test("duration zero", function() {
     assert.strictEqual(est.durationSurvival(0), 1.0, 'zero time = full survival');
-})();
+});
 
-(function testDurationNegative() {
+test("duration negative", function() {
     assert.strictEqual(est.durationSurvival(-10), 1.0, 'negative time = full survival');
-})();
+});
 
-(function testDurationLinear() {
+test("duration linear", function() {
     approx(est.durationSurvival(500), 0.5, 0.001, '500s = 50% survival');
-})();
+});
 
-(function testDurationMax() {
+test("duration max", function() {
     assert.strictEqual(est.durationSurvival(1000), 0, '1000s = 0% survival');
-})();
+});
 
-(function testDurationBeyondMax() {
+test("duration beyond max", function() {
     assert.strictEqual(est.durationSurvival(2000), 0, 'beyond max = clamped to 0');
-})();
+});
 
 // Shear rate estimation
-(function testShearRateFromPressure() {
+test("shear rate from pressure", function() {
     const params = { pressure: 100, nozzleDiameter: 0.4, flowRate: null };
     const gamma = est.estimateShearRate(params);
     assert.ok(gamma > 0, 'should produce positive shear rate');
     assert.ok(isFinite(gamma), 'should be finite');
-})();
+});
 
-(function testShearRateFromFlowRate() {
+test("shear rate from flow rate", function() {
     const params = { pressure: 100, nozzleDiameter: 0.4, flowRate: 1.0 };
     const gamma = est.estimateShearRate(params);
     assert.ok(gamma > 0, 'flow-rate based should produce positive shear');
-})();
+});
 
-(function testShearRateHigherPressure() {
+test("shear rate higher pressure", function() {
     const p1 = { pressure: 50, nozzleDiameter: 0.4, flowRate: null };
     const p2 = { pressure: 150, nozzleDiameter: 0.4, flowRate: null };
     assert.ok(est.estimateShearRate(p2) > est.estimateShearRate(p1),
         'higher pressure = higher shear rate');
-})();
+});
 
-(function testShearRateNozzleSizeWithFlowRate() {
+test("shear rate nozzle size with flow rate", function() {
     // At constant flow rate, smaller nozzle = higher shear rate
     const p1 = { pressure: 100, nozzleDiameter: 0.8, flowRate: 1.0 };
     const p2 = { pressure: 100, nozzleDiameter: 0.2, flowRate: 1.0 };
     assert.ok(est.estimateShearRate(p2) > est.estimateShearRate(p1),
         'smaller nozzle at constant flow = higher shear rate');
-})();
+});
 
-(function testShearRateNozzleSizeWithPressure() {
+test("shear rate nozzle size with pressure", function() {
     // At constant pressure, Hagen-Poiseuille: Q ∝ D⁴, γ ∝ Q/D³ ∝ D
     // So larger nozzle = higher shear rate (more flow, net positive)
     const p1 = { pressure: 100, nozzleDiameter: 0.2, flowRate: null };
     const p2 = { pressure: 100, nozzleDiameter: 0.8, flowRate: null };
     assert.ok(est.estimateShearRate(p2) > est.estimateShearRate(p1),
         'larger nozzle at constant pressure = higher flow = higher shear');
-})();
+});
 
 // ── Combined Estimation ─────────────────────────────────────
 
-(function testEstimateBasic() {
+test("estimate basic", function() {
     const result = est.estimate({ pressure: 80 });
     assert.ok(result.viabilityPercent > 0 && result.viabilityPercent <= 95,
         'viability in valid range');
@@ -207,9 +207,9 @@ function throws(fn, pattern, msg) {
     assert.ok(result.breakdown);
     assert.strictEqual(result.breakdown.baseline, 0.95);
     assert.ok(result.estimatedShearRate > 0);
-})();
+});
 
-(function testEstimateWithAllParams() {
+test("estimate with all params", function() {
     const result = est.estimate({
         pressure: 80,
         crosslinkDuration: 5000,
@@ -222,9 +222,9 @@ function throws(fn, pattern, msg) {
     assert.ok(result.viabilityPercent > 0);
     assert.notStrictEqual(result.breakdown.thermal, null);
     assert.notStrictEqual(result.breakdown.duration, null);
-})();
+});
 
-(function testEstimateLimitingFactor() {
+test("estimate limiting factor", function() {
     // Very high crosslink dose should make crosslink the limiting factor
     const result = est.estimate({
         pressure: 50,
@@ -232,9 +232,9 @@ function throws(fn, pattern, msg) {
         crosslinkIntensity: 80,
     });
     assert.strictEqual(result.limitingFactor, 'crosslink', 'crosslink should be limiting');
-})();
+});
 
-(function testEstimateHighPressureLimiting() {
+test("estimate high pressure limiting", function() {
     const result = est.estimate({
         pressure: 200,
         crosslinkDuration: 0,
@@ -243,9 +243,9 @@ function throws(fn, pattern, msg) {
     // With very high pressure, either pressure or shear should be limiting
     assert.ok(result.limitingFactor === 'pressure' || result.limitingFactor === 'shear',
         'high pressure: limiting should be pressure or shear');
-})();
+});
 
-(function testEstimateWarnings() {
+test("estimate warnings", function() {
     const result = est.estimate({
         pressure: 200,
         crosslinkDuration: 25000,
@@ -254,9 +254,9 @@ function throws(fn, pattern, msg) {
         printDuration: 800,
     });
     assert.ok(result.warnings.length > 0, 'extreme params should generate warnings');
-})();
+});
 
-(function testEstimateNoWarnings() {
+test("estimate no warnings", function() {
     const result = est.estimate({
         pressure: 30,
         crosslinkDuration: 0,
@@ -265,38 +265,38 @@ function throws(fn, pattern, msg) {
     // Low pressure, no crosslinking — should be mostly fine
     assert.ok(result.warnings.length === 0 || result.quality === 'excellent' || result.quality === 'good',
         'gentle params should have few/no warnings');
-})();
+});
 
 // ── Input Validation ────────────────────────────────────────
 
-(function testEstimateNullParams() {
+test("estimate null params", function() {
     throws(function() { est.estimate(null); }, 'non-null object', 'null params');
-})();
+});
 
-(function testEstimateStringParams() {
+test("estimate string params", function() {
     throws(function() { est.estimate('hello'); }, 'non-null object', 'string params');
-})();
+});
 
-(function testEstimateNegativePressure() {
+test("estimate negative pressure", function() {
     throws(function() { est.estimate({ pressure: -10 }); }, '>= 0', 'negative pressure');
-})();
+});
 
-(function testEstimateNaNPressure() {
+test("estimate na n pressure", function() {
     throws(function() { est.estimate({ pressure: NaN }); }, 'finite number', 'NaN pressure');
-})();
+});
 
-(function testEstimateInfinityPressure() {
+test("estimate infinity pressure", function() {
     throws(function() { est.estimate({ pressure: Infinity }); }, 'finite number', 'infinite pressure');
-})();
+});
 
-(function testEstimateCrosslinkIntensityOver100() {
+test("estimate crosslink intensity over100", function() {
     throws(function() { est.estimate({ pressure: 50, crosslinkIntensity: 150 }); },
         '<= 100', 'intensity over 100');
-})();
+});
 
 // ── Sensitivity Analysis ────────────────────────────────────
 
-(function testSensitivityBasic() {
+test("sensitivity basic", function() {
     const sa = est.sensitivityAnalysis({ pressure: 80 }, { steps: 5 });
     assert.ok(sa.pressure, 'should have pressure analysis');
     assert.ok(sa.crosslinkDuration, 'should have crosslink analysis');
@@ -304,9 +304,9 @@ function throws(fn, pattern, msg) {
     assert.ok(Array.isArray(sa._ranking));
     assert.ok(sa.pressure.curve.length > 0, 'should have curve points');
     assert.ok(sa.pressure.sensitivityIndex >= 0, 'index should be non-negative');
-})();
+});
 
-(function testSensitivityRanking() {
+test("sensitivity ranking", function() {
     const sa = est.sensitivityAnalysis({ pressure: 80 }, { steps: 10 });
     // Ranking should be sorted by decreasing sensitivity index
     for (var i = 1; i < sa._ranking.length; i++) {
@@ -314,14 +314,14 @@ function throws(fn, pattern, msg) {
         var curr = sa[sa._ranking[i]].sensitivityIndex;
         assert.ok(prev >= curr, 'ranking should be sorted by sensitivity');
     }
-})();
+});
 
-(function testSensitivityInvalidSteps() {
+test("sensitivity invalid steps", function() {
     throws(function() { est.sensitivityAnalysis({ pressure: 80 }, { steps: 1 }); },
         'between 2 and 200', 'steps too low');
     throws(function() { est.sensitivityAnalysis({ pressure: 80 }, { steps: 201 }); },
         'between 2 and 200', 'steps too high');
-})();
+});
 
 // ── Optimal Window Finder ───────────────────────────────────
 
@@ -358,46 +358,46 @@ const sampleData = [
       user_info: { serial: 5 } },
 ];
 
-(function testOptimalWindowBasic() {
+test("optimal window basic", function() {
     const ow = est.findOptimalWindow(sampleData);
     assert.strictEqual(ow.totalRecords, 6);
     assert.ok(ow.topPercentileCount > 0);
     assert.ok(ow.optimalRanges.pressure);
     assert.ok(ow.recommendations.length > 0);
-})();
+});
 
-(function testOptimalWindowThreshold() {
+test("optimal window threshold", function() {
     const ow = est.findOptimalWindow(sampleData, { viabilityThreshold: 80 });
     assert.ok(ow.aboveThresholdCount <= ow.totalRecords);
     assert.strictEqual(ow.viabilityThreshold, 80);
-})();
+});
 
-(function testOptimalWindowPercentile() {
+test("optimal window percentile", function() {
     const ow = est.findOptimalWindow(sampleData, { topPercentile: 50 });
     assert.strictEqual(ow.topPercentile, 50);
     assert.ok(ow.topPercentileCount >= Math.ceil(6 * 0.5));
-})();
+});
 
-(function testOptimalWindowEmpty() {
+test("optimal window empty", function() {
     throws(function() { est.findOptimalWindow([]); }, 'non-empty array', 'empty data');
-})();
+});
 
-(function testOptimalWindowInvalid() {
+test("optimal window invalid", function() {
     throws(function() { est.findOptimalWindow(null); }, 'non-empty array', 'null data');
-})();
+});
 
 // ── Batch Analysis ──────────────────────────────────────────
 
-(function testBatchAnalyzeBasic() {
+test("batch analyze basic", function() {
     const batch = est.batchAnalyze(sampleData);
     assert.strictEqual(batch.count, 6);
     assert.ok(batch.accuracy.rmse >= 0);
     assert.ok(batch.accuracy.mae >= 0);
     assert.ok(batch.accuracy.correlation >= -1 && batch.accuracy.correlation <= 1);
     assert.ok(batch.results.length === 6);
-})();
+});
 
-(function testBatchAnalyzeResultFields() {
+test("batch analyze result fields", function() {
     const batch = est.batchAnalyze(sampleData);
     const r = batch.results[0];
     assert.ok('predicted' in r);
@@ -406,27 +406,27 @@ const sampleData = [
     assert.ok('absError' in r);
     assert.ok('quality' in r);
     assert.ok('limitingFactor' in r);
-})();
+});
 
-(function testBatchAnalyzeQualityDist() {
+test("batch analyze quality dist", function() {
     const batch = est.batchAnalyze(sampleData);
     const total = Object.values(batch.qualityDistribution).reduce(function(s, v) { return s + v; }, 0);
     assert.strictEqual(total, 6, 'quality distribution should account for all records');
-})();
+});
 
-(function testBatchAnalyzeEmpty() {
+test("batch analyze empty", function() {
     throws(function() { est.batchAnalyze([]); }, 'non-empty array', 'empty batch');
-})();
+});
 
-(function testBatchAnalyzeSkipsInvalid() {
+test("batch analyze skips invalid", function() {
     const data = [null, { print_data: null }, sampleData[0]];
     const batch = est.batchAnalyze(data);
     assert.strictEqual(batch.count, 1, 'should skip invalid records');
-})();
+});
 
 // ── Parameter Sweep ─────────────────────────────────────────
 
-(function testParameterSweepBasic() {
+test("parameter sweep basic", function() {
     const sweep = est.parameterSweep(
         { pressure: 80, nozzleDiameter: 0.4 },
         'pressure', { min: 20, max: 200 },
@@ -438,9 +438,9 @@ const sampleData = [
     assert.strictEqual(sweep.resolution, 3);
     assert.strictEqual(sweep.grid.length, 4);  // resolution + 1
     assert.ok(sweep.peak.viability > sweep.trough.viability, 'peak > trough');
-})();
+});
 
-(function testParameterSweepPeakLocation() {
+test("parameter sweep peak location", function() {
     const sweep = est.parameterSweep(
         { pressure: 80, nozzleDiameter: 0.4 },
         'pressure', { min: 20, max: 200 },
@@ -450,52 +450,52 @@ const sampleData = [
     // Peak should be at low pressure and low crosslink duration
     assert.ok(sweep.peak.pressure <= 100, 'optimal pressure should be low-moderate');
     assert.ok(sweep.peak.crosslinkDuration <= 10000, 'optimal crosslink should be low-moderate');
-})();
+});
 
-(function testParameterSweepInvalidRange() {
+test("parameter sweep invalid range", function() {
     throws(function() {
         est.parameterSweep({pressure: 80}, 'pressure', null, 'crosslinkDuration', {min: 0, max: 100});
     }, 'range1 must have numeric', 'null range1');
-})();
+});
 
-(function testParameterSweepInvalidResolution() {
+test("parameter sweep invalid resolution", function() {
     throws(function() {
         est.parameterSweep({pressure: 80}, 'pressure', {min: 0, max: 100},
             'crosslinkDuration', {min: 0, max: 100}, {resolution: 1});
     }, 'between 2 and 50', 'resolution too low');
-})();
+});
 
 // ── Calibration ─────────────────────────────────────────────
 
-(function testCalibrateBasic() {
+test("calibrate basic", function() {
     const cal = est.calibrate(sampleData, { steps: 2 });
     assert.ok(cal.calibratedParams.pressure.p50 > 0);
     assert.ok(cal.calibratedParams.crosslink.ec50 > 0);
     assert.ok(cal.accuracy.rmse >= 0);
     assert.ok(cal.searchSpace.combinations > 0);
-})();
+});
 
-(function testCalibrateTooFewRecords() {
+test("calibrate too few records", function() {
     throws(function() { est.calibrate(sampleData.slice(0, 3)); },
         'at least 5 records', 'too few records');
-})();
+});
 
 // ── Report Generation ───────────────────────────────────────
 
-(function testGenerateReportBasic() {
+test("generate report basic", function() {
     const report = est.generateReport({ pressure: 80 });
     assert.ok(report.timestamp);
     assert.ok(report.estimation);
     assert.ok(Array.isArray(report.recommendations));
     assert.ok(report.sensitivity, 'should include sensitivity by default');
-})();
+});
 
-(function testGenerateReportNoSensitivity() {
+test("generate report no sensitivity", function() {
     const report = est.generateReport({ pressure: 80 }, { includeSensitivity: false });
     assert.ok(!report.sensitivity, 'sensitivity should be excluded');
-})();
+});
 
-(function testGenerateReportRecommendations() {
+test("generate report recommendations", function() {
     // High pressure and high UV should generate recommendations
     const report = est.generateReport({
         pressure: 200,
@@ -507,56 +507,46 @@ const sampleData = [
         return r.parameter === 'shear' || r.parameter === 'pressure';
     });
     assert.ok(hasShearOrPressure, 'should recommend pressure/shear adjustment');
-})();
+});
 
 // ── Edge Cases ──────────────────────────────────────────────
 
-(function testEstimateZeroPressure() {
+test("estimate zero pressure", function() {
     var result = est.estimate({ pressure: 0 });
     assert.ok(result.viabilityPercent > 90, 'zero pressure should give near-max viability');
-})();
+});
 
-(function testEstimateVeryHighPressure() {
+test("estimate very high pressure", function() {
     var result = est.estimate({ pressure: 500 });
     assert.ok(result.viabilityPercent < 10, 'extreme pressure should near-zero viability');
-})();
+});
 
-(function testEstimateNoCrosslinking() {
+test("estimate no crosslinking", function() {
     var result = est.estimate({ pressure: 80, crosslinkDuration: 0, crosslinkIntensity: 0 });
     assert.strictEqual(result.breakdown.crosslink, 1, 'no crosslinking = 1.0 survival');
-})();
+});
 
-(function testEstimateMultiplicativeModel() {
+test("estimate multiplicative model", function() {
     // Verify multiplicative: V = baseline * shear * pressure * crosslink
     var result = est.estimate({ pressure: 80, crosslinkDuration: 5000, crosslinkIntensity: 20 });
     var expected = result.breakdown.baseline * result.breakdown.shear *
                    result.breakdown.pressure * result.breakdown.crosslink * 100;
     approx(result.viabilityPercent, expected, 0.1, 'multiplicative model check');
-})();
+});
 
-(function testDefaultParamsFrozen() {
+test("default params frozen", function() {
     assert.ok(Object.isFrozen(est.DEFAULT_PARAMS), 'DEFAULT_PARAMS should be frozen');
     assert.ok(Object.isFrozen(est.DEFAULT_PARAMS.shear), 'shear params should be frozen');
     assert.ok(Object.isFrozen(est.DEFAULT_PARAMS.pressure), 'pressure params should be frozen');
-})();
+});
 
 // ── Custom Model Params ─────────────────────────────────────
 
-(function testEstimateCustomBaseline() {
+test("estimate custom baseline", function() {
     var result = est.estimate({ pressure: 0 }, { baseline: 1.0,
         shear: est.DEFAULT_PARAMS.shear,
         pressure: est.DEFAULT_PARAMS.pressure,
         crosslink: est.DEFAULT_PARAMS.crosslink });
     assert.ok(result.viabilityPercent > 95, 'baseline 1.0 with zero stress should give ~100%');
-})();
+});
 
-// ── Summary ─────────────────────────────────────────────────
-
-var testCount = 0;
-// Count tests by pattern matching (each IIFE is a test)
-var fs = require('fs');
-var src = fs.readFileSync(__filename, 'utf8');
-var matches = src.match(/\(function test/g);
-testCount = matches ? matches.length : 0;
-
-console.log('All ' + testCount + ' viability estimator tests passed ✓');


### PR DESCRIPTION
## Problem
\	ests/viability.test.js\ used raw IIFEs instead of Jest's \	est()\ function, causing Jest to fail with:
> Your test suite must contain at least one test.

This was the only failing suite in the project (59/60 passing).

## Fix
- Converted all 71 IIFE test functions to \	est()\ calls with descriptive names
- Removed the manual test counter (Jest handles counting natively)
- Test names derived from original function names (e.g. \	estShearSurvivalZero\ → \shear survival zero\)

## Result
All 60 test suites now pass (3166 tests total).