### PR TITLE
fix: G90/G91 should not override extruder axis mode

### DIFF
--- a/__tests__/gcode.test.js
+++ b/__tests__/gcode.test.js
@@ -429,11 +429,14 @@ describe('createGCodeAnalyzer', function () {
 
         test('handles absolute/relative mode switches', function () {
             var gcode = [
-                'G90',                // absolute
+                'G90',                // absolute XYZ
+                'M82',                // absolute E
                 'G1 X10 E2 F1000',   // abs: x=10, e=2
-                'G91',                // relative
+                'G91',                // relative XYZ
+                'M83',                // relative E
                 'G1 X5 E1 F1000',    // rel: x=15, e=3
-                'G90',                // back to absolute
+                'G90',                // back to absolute XYZ (E stays relative per M83)
+                'M82',                // back to absolute E
                 'G1 X20 E5 F1000'    // abs: x=20, e=5
             ].join('\n');
             var result = analyzer.analyze(gcode);

--- a/docs/shared/gcode.js
+++ b/docs/shared/gcode.js
@@ -269,11 +269,14 @@ function createGCodeAnalyzer() {
 
             } else if (cmd === 'G90') {
                 isAbsoluteXYZ = true;
-                isAbsoluteE = true;
+                // Note: G90 only affects XYZ axes. The extruder (E axis)
+                // mode is controlled independently by M82/M83. Setting
+                // isAbsoluteE here would break the common G90+M83 combo
+                // (absolute positioning with relative extrusion).
 
             } else if (cmd === 'G91') {
                 isAbsoluteXYZ = false;
-                isAbsoluteE = false;
+                // Same as above: G91 does not affect E axis mode.
 
             } else if (cmd === 'M82') {
                 isAbsoluteE = true;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "biobots-tool",
-  "version": "1.0.0",
+  "name": "@sauravbhattacharya001/biobots",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "biobots-tool",
-      "version": "1.0.0",
+      "name": "@sauravbhattacharya001/biobots",
+      "version": "1.1.0",
       "license": "MIT",
       "devDependencies": {
         "jest": "^30.2.0",


### PR DESCRIPTION
## Bug

G90 (absolute positioning) and G91 (relative positioning) were incorrectly setting the extruder axis mode (isAbsoluteE). In standard GCode, these commands only affect XYZ axes — the E axis is controlled independently by M82/M83.

This caused incorrect extrusion calculations when slicers use the common G90+M83 pattern (absolute XYZ with relative extrusion).

## Fix

- Removed isAbsoluteE assignment from G90/G91 handlers in gcode.js
- Updated the mode-switch test to properly use M82/M83 for E-axis control

## Testing

All 60 GCode tests pass.