### PR TITLE
cleanup: adopt scriptUtils shared helpers in 5 modules

### DIFF
--- a/Try/scripts/formulationCalculator.js
+++ b/Try/scripts/formulationCalculator.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { round } = require('./scriptUtils');
+
 /**
  * Bioink Formulation Calculator for BioBots
  *
@@ -890,11 +892,6 @@ function createFormulationCalculator() {
         if (density >= 1e6) return `${round(density / 1e6, 1)} × 10⁶ cells/mL`;
         if (density >= 1e3) return `${round(density / 1e3, 1)} × 10³ cells/mL`;
         return `${density} cells/mL`;
-    }
-
-    function round(val, decimals) {
-        const f = Math.pow(10, decimals);
-        return Math.round(val * f) / f;
     }
 
     // ── List Materials ──────────────────────────────────────────

--- a/Try/scripts/mlDiagnostic.js
+++ b/Try/scripts/mlDiagnostic.js
@@ -1,3 +1,7 @@
+'use strict';
+
+const { clamp } = require('./scriptUtils');
+
 /**
  * ML-Based Pattern Recognition for Print Failure Diagnostics
  *
@@ -319,7 +323,7 @@ function createMLDiagnostic(options) {
 
     const cOpts = clusterOpts || {};
     // Auto-select k: sqrt(n/2), bounded 2..8
-    const autoK = Math.max(2, Math.min(8, Math.round(Math.sqrt(diagnosisVectors.length / 2))));
+    const autoK = clamp(Math.round(Math.sqrt(diagnosisVectors.length / 2)), 2, 8);
     const k = cOpts.k || autoK;
     const maxIter = cOpts.maxIterations || 50;
 

--- a/Try/scripts/nozzlePlanner.js
+++ b/Try/scripts/nozzlePlanner.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { clamp } = require('./scriptUtils');
+
 /**
  * Multi-Nozzle Coordination Planner for BioBots
  *
@@ -670,7 +672,7 @@ function createNozzlePlanner(userConfig) {
         score -= overhead * 0.8;
         score -= pingPongs * 5;
         score -= heavyLayers * 3;
-        return Math.max(0, Math.min(100, Math.round(score)));
+        return clamp(Math.round(score), 0, 100);
     }
 
     // ── Material compatibility check ───────────────────────────

--- a/Try/scripts/shelfLife.js
+++ b/Try/scripts/shelfLife.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { clamp } = require('./scriptUtils');
+
 /**
  * Bioink Shelf Life Tracker for BioBots
  *
@@ -282,8 +284,8 @@ function createShelfLifeTracker(userConfig) {
         var remainingDays = effectiveTotalDays - elapsedDays;
         if (remainingDays < 0) remainingDays = 0;
 
-        var qualityPercent = Math.max(0, Math.min(100,
-            (remainingDays / effectiveTotalDays) * 100));
+        var qualityPercent = clamp(
+            (remainingDays / effectiveTotalDays) * 100, 0, 100);
 
         var status;
         if (remainingDays <= 0) {

--- a/Try/scripts/sterilization.js
+++ b/Try/scripts/sterilization.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { validatePositive, validateNonNegative } = require('./scriptUtils');
+
 /**
  * Sterilization Protocol Analyzer for BioBots
  *
@@ -364,9 +366,7 @@ function createSterilizationAnalyzer(userConfig) {
      */
     function calculateKillKinetics(method, duration, pathogenName) {
         _validateMethod(method);
-        if (typeof duration !== 'number' || duration < 0) {
-            throw new Error('Duration must be a non-negative number');
-        }
+        validateNonNegative(duration, 'Duration');
         var lookup = _lookupPathogen(pathogenName);
         var dValue = lookup.data[method];
         if (dValue == null) {
@@ -415,9 +415,7 @@ function createSterilizationAnalyzer(userConfig) {
      */
     function generateKillCurve(method, maxDuration, steps, pathogenName) {
         _validateMethod(method);
-        if (typeof maxDuration !== 'number' || maxDuration <= 0) {
-            throw new Error('maxDuration must be a positive number');
-        }
+        validatePositive(maxDuration, 'maxDuration');
         var nSteps = (typeof steps === 'number' && steps >= 2) ? steps : 20;
         var lookup = _lookupPathogen(pathogenName);
 


### PR DESCRIPTION
Replaces inline reimplementations of `scriptUtils` helpers in 5 modules that hadn't adopted the shared utilities.

## Changes

| Module | Before | After |
|--------|--------|-------|
| `formulationCalculator.js` | Local `round()` (exact copy of `scriptUtils.round`) | Import from `scriptUtils` |
| `nozzlePlanner.js` | `Math.max(0, Math.min(100, ...))` | `clamp(..., 0, 100)` |
| `mlDiagnostic.js` | `Math.max(2, Math.min(8, ...))` | `clamp(..., 2, 8)` |
| `shelfLife.js` | `Math.max(0, Math.min(100, ...))` | `clamp(..., 0, 100)` |
| `sterilization.js` | Inline `typeof`/`throw` checks | `validatePositive()` / `validateNonNegative()` |

## Testing
- All 3174 tests pass
- All 382 tests in affected modules pass
