### PR TITLE
feat: Lab Audit Trail — immutable hash-chained event log (54 tests)

### DIFF
--- a/Try/scripts/labAuditTrail.js
+++ b/Try/scripts/labAuditTrail.js
@@ -1,0 +1,288 @@
+'use strict';
+
+/**
+ * Lab Audit Trail — Immutable, hash-chained event log for bioprinting operations.
+ *
+ * Records all significant lab events (prints, calibrations, material changes,
+ * environmental readings, protocol modifications) in a tamper-evident chain.
+ * Each entry is linked to the previous via FNV-1a hashing, enabling integrity
+ * verification for GLP/GMP compliance.
+ *
+ * @example
+ *   var trail = createLabAuditTrail();
+ *   trail.recordEvent({ type: 'print_start', operator: 'Dr. Chen',
+ *     data: { protocol: 'skin-scaffold', material: 'collagen-type-i' }});
+ *   trail.recordEvent({ type: 'calibration', operator: 'Lab Tech 1',
+ *     data: { module: 'extruder-A', result: 'pass' }});
+ *   var report = trail.getComplianceReport();
+ *   console.log(report.chainIntegrity); // 'intact'
+ */
+
+var EVENT_TYPES = {
+  print_start:      { category: 'print',       severity: 'info',     label: 'Print Started' },
+  print_complete:   { category: 'print',       severity: 'info',     label: 'Print Completed' },
+  print_abort:      { category: 'print',       severity: 'warning',  label: 'Print Aborted' },
+  print_pause:      { category: 'print',       severity: 'info',     label: 'Print Paused' },
+  print_resume:     { category: 'print',       severity: 'info',     label: 'Print Resumed' },
+  print_error:      { category: 'print',       severity: 'critical', label: 'Print Error' },
+  calibration:      { category: 'calibration',  severity: 'info',     label: 'Calibration Performed' },
+  calibration_fail: { category: 'calibration',  severity: 'warning',  label: 'Calibration Failed' },
+  material_loaded:  { category: 'material',     severity: 'info',     label: 'Material Loaded' },
+  material_changed: { category: 'material',     severity: 'info',     label: 'Material Changed' },
+  material_expired: { category: 'material',     severity: 'warning',  label: 'Material Expired' },
+  material_lot:     { category: 'material',     severity: 'info',     label: 'New Lot Received' },
+  env_reading:      { category: 'environment',  severity: 'info',     label: 'Environmental Reading' },
+  env_alert:        { category: 'environment',  severity: 'warning',  label: 'Environmental Alert' },
+  env_violation:    { category: 'environment',  severity: 'critical', label: 'Environmental Violation' },
+  protocol_loaded:  { category: 'protocol',     severity: 'info',     label: 'Protocol Loaded' },
+  protocol_modified:{ category: 'protocol',     severity: 'warning',  label: 'Protocol Modified' },
+  protocol_approved:{ category: 'protocol',     severity: 'info',     label: 'Protocol Approved' },
+  maintenance_done: { category: 'maintenance',  severity: 'info',     label: 'Maintenance Completed' },
+  maintenance_due:  { category: 'maintenance',  severity: 'warning',  label: 'Maintenance Due' },
+  operator_login:   { category: 'operator',     severity: 'info',     label: 'Operator Login' },
+  operator_logout:  { category: 'operator',     severity: 'info',     label: 'Operator Logout' },
+  operator_note:    { category: 'operator',     severity: 'info',     label: 'Operator Note' },
+  quality_check:    { category: 'quality',      severity: 'info',     label: 'Quality Check' },
+  quality_fail:     { category: 'quality',      severity: 'critical', label: 'Quality Check Failed' },
+  sample_collected: { category: 'quality',      severity: 'info',     label: 'Sample Collected' },
+  system_start:     { category: 'system',       severity: 'info',     label: 'System Started' },
+  system_shutdown:  { category: 'system',       severity: 'info',     label: 'System Shutdown' },
+  system_error:     { category: 'system',       severity: 'critical', label: 'System Error' },
+};
+
+var CATEGORIES = ['print', 'calibration', 'material', 'environment',
+                  'protocol', 'maintenance', 'operator', 'quality', 'system'];
+
+function fnv1aHash(str) {
+  var hash = 0x811c9dc5;
+  for (var i = 0; i < str.length; i++) {
+    hash ^= str.charCodeAt(i);
+    hash = (hash * 0x01000193) >>> 0;
+  }
+  var hex = hash.toString(16);
+  while (hex.length < 8) hex = '0' + hex;
+  return hex;
+}
+
+function computeEntryHash(entry, prevHash) {
+  var payload = prevHash + '|' + entry.timestamp + '|' + entry.type + '|' +
+    entry.operator + '|' + JSON.stringify(entry.data || {});
+  return fnv1aHash(payload);
+}
+
+function createLabAuditTrail(options) {
+  options = options || {};
+  var _entries = [];
+  var _lastHash = options.genesisHash || '00000000';
+  var _locked = false;
+  var _retentionDays = options.retentionDays || 365;
+  var _maxEntries = options.maxEntries || 100000;
+
+  function recordEvent(evt) {
+    if (_locked) throw new Error('Audit trail is locked (archived). No new entries allowed.');
+    if (!evt || !evt.type) throw new Error('Event must have a type.');
+    if (!EVENT_TYPES[evt.type]) throw new Error('Unknown event type: ' + evt.type +
+      '. Valid types: ' + Object.keys(EVENT_TYPES).join(', '));
+    if (!evt.operator || typeof evt.operator !== 'string' || !evt.operator.trim())
+      throw new Error('Event must have a non-empty operator string.');
+
+    var meta = EVENT_TYPES[evt.type];
+    var entry = {
+      id: _entries.length + 1,
+      timestamp: evt.timestamp || new Date().toISOString(),
+      type: evt.type, category: meta.category,
+      severity: meta.severity, label: meta.label,
+      operator: evt.operator.trim(),
+      data: evt.data || {}, notes: evt.notes || '',
+      prevHash: _lastHash, hash: ''
+    };
+    entry.hash = computeEntryHash(entry, _lastHash);
+    _lastHash = entry.hash;
+    _entries.push(entry);
+    if (_entries.length > _maxEntries) _entries = _entries.slice(_entries.length - _maxEntries);
+    return { id: entry.id, hash: entry.hash };
+  }
+
+  function getEntries(filter) {
+    filter = filter || {};
+    var result = _entries.slice();
+    if (filter.type) result = result.filter(function(e) { return e.type === filter.type; });
+    if (filter.category) result = result.filter(function(e) { return e.category === filter.category; });
+    if (filter.severity) result = result.filter(function(e) { return e.severity === filter.severity; });
+    if (filter.operator) {
+      var op = filter.operator.toLowerCase();
+      result = result.filter(function(e) { return e.operator.toLowerCase() === op; });
+    }
+    if (filter.from) {
+      var from = new Date(filter.from).getTime();
+      result = result.filter(function(e) { return new Date(e.timestamp).getTime() >= from; });
+    }
+    if (filter.to) {
+      var to = new Date(filter.to).getTime();
+      result = result.filter(function(e) { return new Date(e.timestamp).getTime() <= to; });
+    }
+    if (filter.search) {
+      var term = filter.search.toLowerCase();
+      result = result.filter(function(e) {
+        return e.notes.toLowerCase().indexOf(term) !== -1 ||
+               e.label.toLowerCase().indexOf(term) !== -1 ||
+               JSON.stringify(e.data).toLowerCase().indexOf(term) !== -1;
+      });
+    }
+    if (typeof filter.limit === 'number' && filter.limit > 0) result = result.slice(-filter.limit);
+    return result;
+  }
+
+  function getEntry(id) { return _entries.find(function(e) { return e.id === id; }) || null; }
+  function getCount() { return _entries.length; }
+
+  function verifyIntegrity() {
+    if (_entries.length === 0) return { intact: true, entries: 0, errors: [] };
+    var errors = [], prevHash = _entries[0].prevHash;
+    for (var i = 0; i < _entries.length; i++) {
+      var entry = _entries[i];
+      if (entry.prevHash !== prevHash)
+        errors.push({ id: entry.id, issue: 'broken_chain', expected: prevHash, found: entry.prevHash });
+      var recomputed = computeEntryHash(entry, entry.prevHash);
+      if (entry.hash !== recomputed)
+        errors.push({ id: entry.id, issue: 'hash_mismatch', expected: recomputed, found: entry.hash });
+      prevHash = entry.hash;
+    }
+    return { intact: errors.length === 0, entries: _entries.length,
+      firstEntry: _entries[0].timestamp, lastEntry: _entries[_entries.length - 1].timestamp, errors: errors };
+  }
+
+  function getStatistics() {
+    var byCat = {}, bySev = { info: 0, warning: 0, critical: 0 };
+    var byOp = {}, byType = {}, hourly = {};
+    CATEGORIES.forEach(function(c) { byCat[c] = 0; });
+    _entries.forEach(function(e) {
+      byCat[e.category] = (byCat[e.category] || 0) + 1;
+      bySev[e.severity] = (bySev[e.severity] || 0) + 1;
+      byOp[e.operator] = (byOp[e.operator] || 0) + 1;
+      byType[e.type] = (byType[e.type] || 0) + 1;
+      var h = new Date(e.timestamp).getHours();
+      hourly[h] = (hourly[h] || 0) + 1;
+    });
+    var peakHour = null, peakCount = 0, topOp = null, topOpCount = 0;
+    Object.keys(hourly).forEach(function(h) { if (hourly[h] > peakCount) { peakCount = hourly[h]; peakHour = parseInt(h, 10); } });
+    Object.keys(byOp).forEach(function(op) { if (byOp[op] > topOpCount) { topOpCount = byOp[op]; topOp = op; } });
+    return { totalEvents: _entries.length, byCategory: byCat, bySeverity: bySev,
+      byOperator: byOp, byType: byType, peakHour: peakHour,
+      topOperator: topOp, uniqueOperators: Object.keys(byOp).length };
+  }
+
+  function getOperatorActivity(operator) {
+    var ops = _entries.filter(function(e) { return e.operator.toLowerCase() === operator.toLowerCase(); });
+    if (ops.length === 0) return null;
+    var types = {};
+    ops.forEach(function(e) { types[e.type] = (types[e.type] || 0) + 1; });
+    return { operator: operator, totalEvents: ops.length, eventTypes: types,
+      firstEvent: ops[0].timestamp, lastEvent: ops[ops.length - 1].timestamp,
+      criticalEvents: ops.filter(function(e) { return e.severity === 'critical'; }).length,
+      warningEvents: ops.filter(function(e) { return e.severity === 'warning'; }).length };
+  }
+
+  function getComplianceReport() {
+    var integrity = verifyIntegrity(), stats = getStatistics();
+    var now = Date.now(), thirtyDaysAgo = now - 30 * 86400000, daysWithEvents = {};
+    _entries.forEach(function(e) {
+      var ts = new Date(e.timestamp).getTime();
+      if (ts >= thirtyDaysAgo) daysWithEvents[new Date(e.timestamp).toISOString().slice(0, 10)] = true;
+    });
+    var gapDays = [];
+    for (var d = thirtyDaysAgo; d < now; d += 86400000) {
+      var dayStr = new Date(d).toISOString().slice(0, 10);
+      if (!daysWithEvents[dayStr]) gapDays.push(dayStr);
+    }
+    var sevenDaysAgo = now - 7 * 86400000, recentTypes = {};
+    _entries.forEach(function(e) { if (new Date(e.timestamp).getTime() >= sevenDaysAgo) recentTypes[e.type] = true; });
+    var missingChecks = [];
+    if (!recentTypes['calibration']) missingChecks.push('calibration');
+    if (!recentTypes['env_reading']) missingChecks.push('environmental_reading');
+    if (!recentTypes['quality_check']) missingChecks.push('quality_check');
+    if (!recentTypes['maintenance_done']) missingChecks.push('maintenance');
+    var unresolvedCritical = _entries.filter(function(e) { return e.severity === 'critical'; });
+    var score = 100;
+    if (!integrity.intact) score -= 30;
+    score -= Math.min(20, gapDays.length * 2);
+    score -= missingChecks.length * 5;
+    score -= Math.min(15, unresolvedCritical.length * 3);
+    score = Math.max(0, score);
+    var grade = score >= 90 ? 'A' : score >= 80 ? 'B' : score >= 70 ? 'C' : score >= 60 ? 'D' : 'F';
+    return { chainIntegrity: integrity.intact ? 'intact' : 'compromised',
+      integrityErrors: integrity.errors, totalEvents: stats.totalEvents,
+      bySeverity: stats.bySeverity, coverageGapDays: gapDays.length, coverageGaps: gapDays,
+      missingWeeklyChecks: missingChecks, unresolvedCriticalCount: unresolvedCritical.length,
+      complianceScore: score, complianceGrade: grade,
+      uniqueOperators: stats.uniqueOperators, peakHour: stats.peakHour };
+  }
+
+  function getTimeline(opts) {
+    opts = opts || {};
+    var entries = getEntries(opts), grouped = {};
+    entries.forEach(function(e) {
+      var day = e.timestamp.slice(0, 10);
+      if (!grouped[day]) grouped[day] = [];
+      grouped[day].push({ time: e.timestamp.slice(11, 19), type: e.type, label: e.label,
+        severity: e.severity, operator: e.operator, notes: e.notes });
+    });
+    return { days: Object.keys(grouped).sort(), timeline: grouped, totalEvents: entries.length };
+  }
+
+  function exportJSON() {
+    return { exportedAt: new Date().toISOString(),
+      genesisHash: _entries.length > 0 ? _entries[0].prevHash : _lastHash,
+      entries: _entries.map(function(e) {
+        return { id: e.id, timestamp: e.timestamp, type: e.type, category: e.category,
+          severity: e.severity, operator: e.operator, data: e.data, notes: e.notes,
+          prevHash: e.prevHash, hash: e.hash };
+      }), integrity: verifyIntegrity() };
+  }
+
+  function exportCSV() {
+    var header = 'ID,Timestamp,Type,Category,Severity,Operator,Notes,Hash\n';
+    var rows = _entries.map(function(e) {
+      return [e.id, e.timestamp, e.type, e.category, e.severity,
+        '"' + e.operator.replace(/"/g, '""') + '"',
+        '"' + (e.notes || '').replace(/"/g, '""') + '"', e.hash].join(',');
+    });
+    return header + rows.join('\n');
+  }
+
+  function importJSON(data) {
+    if (!data || !Array.isArray(data.entries)) throw new Error('Invalid import data: must have entries array.');
+    if (_entries.length > 0) throw new Error('Cannot import into non-empty trail. Create a new instance.');
+    _entries = []; _lastHash = data.genesisHash || '00000000';
+    data.entries.forEach(function(e) {
+      _entries.push({ id: e.id, timestamp: e.timestamp, type: e.type,
+        category: e.category || (EVENT_TYPES[e.type] || {}).category || 'system',
+        severity: e.severity || (EVENT_TYPES[e.type] || {}).severity || 'info',
+        label: (EVENT_TYPES[e.type] || {}).label || e.type,
+        operator: e.operator, data: e.data || {}, notes: e.notes || '',
+        prevHash: e.prevHash, hash: e.hash });
+      _lastHash = e.hash;
+    });
+    return verifyIntegrity();
+  }
+
+  function lock() { _locked = true; }
+  function isLocked() { return _locked; }
+
+  function purgeExpired() {
+    var cutoff = Date.now() - _retentionDays * 86400000, before = _entries.length;
+    _entries = _entries.filter(function(e) { return new Date(e.timestamp).getTime() >= cutoff; });
+    return { purged: before - _entries.length, remaining: _entries.length };
+  }
+
+  return { recordEvent: recordEvent, getEntries: getEntries, getEntry: getEntry,
+    getCount: getCount, verifyIntegrity: verifyIntegrity, getStatistics: getStatistics,
+    getOperatorActivity: getOperatorActivity, getComplianceReport: getComplianceReport,
+    getTimeline: getTimeline, exportJSON: exportJSON, exportCSV: exportCSV,
+    importJSON: importJSON, lock: lock, isLocked: isLocked, purgeExpired: purgeExpired,
+    EVENT_TYPES: EVENT_TYPES, CATEGORIES: CATEGORIES };
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { createLabAuditTrail: createLabAuditTrail };
+}

--- a/__tests__/labAuditTrail.test.js
+++ b/__tests__/labAuditTrail.test.js
@@ -1,0 +1,457 @@
+'use strict';
+
+var _mod = require('../Try/scripts/labAuditTrail');
+var createLabAuditTrail = _mod.createLabAuditTrail;
+
+function mkEvent(type, operator, data) {
+  return { type: type, operator: operator || 'Dr. Chen', data: data || {} };
+}
+
+function seedTrail(n) {
+  var trail = createLabAuditTrail();
+  var types = ['print_start', 'calibration', 'material_loaded', 'env_reading', 'quality_check'];
+  var ops = ['Dr. Chen', 'Lab Tech 1', 'Dr. Smith'];
+  var now = Date.now();
+  for (var i = 0; i < n; i++) {
+    trail.recordEvent({
+      type: types[i % types.length],
+      operator: ops[i % ops.length],
+      data: { index: i },
+      timestamp: new Date(now - (n - i) * 3600 * 1000).toISOString()
+    });
+  }
+  return trail;
+}
+
+describe('createLabAuditTrail', () => {
+  test('creates a trail with zero entries', () => {
+    var trail = createLabAuditTrail();
+    expect(trail.getCount()).toBe(0);
+    expect(trail.getEntries()).toEqual([]);
+  });
+
+  test('exposes EVENT_TYPES and CATEGORIES', () => {
+    var trail = createLabAuditTrail();
+    expect(Object.keys(trail.EVENT_TYPES).length).toBeGreaterThan(20);
+    expect(trail.CATEGORIES).toContain('print');
+    expect(trail.CATEGORIES).toContain('quality');
+  });
+});
+
+describe('recordEvent', () => {
+  test('records a valid event and returns id + hash', () => {
+    var trail = createLabAuditTrail();
+    var result = trail.recordEvent(mkEvent('print_start', 'Dr. Chen', { protocol: 'skin' }));
+    expect(result.id).toBe(1);
+    expect(typeof result.hash).toBe('string');
+    expect(result.hash.length).toBe(8);
+    expect(trail.getCount()).toBe(1);
+  });
+
+  test('assigns incremental IDs', () => {
+    var trail = createLabAuditTrail();
+    trail.recordEvent(mkEvent('print_start', 'A'));
+    trail.recordEvent(mkEvent('print_complete', 'A'));
+    var r3 = trail.recordEvent(mkEvent('calibration', 'A'));
+    expect(r3.id).toBe(3);
+  });
+
+  test('throws on missing type', () => {
+    var trail = createLabAuditTrail();
+    expect(() => trail.recordEvent({ operator: 'A' })).toThrow('type');
+  });
+
+  test('throws on unknown type', () => {
+    var trail = createLabAuditTrail();
+    expect(() => trail.recordEvent({ type: 'bogus', operator: 'A' })).toThrow('Unknown event type');
+  });
+
+  test('throws on missing operator', () => {
+    var trail = createLabAuditTrail();
+    expect(() => trail.recordEvent({ type: 'print_start' })).toThrow('operator');
+  });
+
+  test('throws on empty operator', () => {
+    var trail = createLabAuditTrail();
+    expect(() => trail.recordEvent({ type: 'print_start', operator: '  ' })).toThrow('operator');
+  });
+
+  test('trims operator whitespace', () => {
+    var trail = createLabAuditTrail();
+    trail.recordEvent(mkEvent('print_start', '  Bob  '));
+    expect(trail.getEntries()[0].operator).toBe('Bob');
+  });
+
+  test('auto-populates category, severity, label from EVENT_TYPES', () => {
+    var trail = createLabAuditTrail();
+    trail.recordEvent(mkEvent('print_error', 'A'));
+    var entry = trail.getEntries()[0];
+    expect(entry.category).toBe('print');
+    expect(entry.severity).toBe('critical');
+    expect(entry.label).toBe('Print Error');
+  });
+
+  test('stores data and notes', () => {
+    var trail = createLabAuditTrail();
+    trail.recordEvent({ type: 'operator_note', operator: 'A', data: { foo: 1 }, notes: 'checked pressure' });
+    var e = trail.getEntries()[0];
+    expect(e.data.foo).toBe(1);
+    expect(e.notes).toBe('checked pressure');
+  });
+
+  test('uses provided timestamp if given', () => {
+    var trail = createLabAuditTrail();
+    var ts = '2025-06-15T10:00:00.000Z';
+    trail.recordEvent({ type: 'calibration', operator: 'A', timestamp: ts });
+    expect(trail.getEntries()[0].timestamp).toBe(ts);
+  });
+
+  test('throws when trail is locked', () => {
+    var trail = createLabAuditTrail();
+    trail.lock();
+    expect(() => trail.recordEvent(mkEvent('print_start', 'A'))).toThrow('locked');
+  });
+});
+
+describe('hash chaining', () => {
+  test('each entry has prevHash linking to prior entry hash', () => {
+    var trail = createLabAuditTrail();
+    trail.recordEvent(mkEvent('print_start', 'A'));
+    trail.recordEvent(mkEvent('print_complete', 'A'));
+    var entries = trail.getEntries();
+    expect(entries[1].prevHash).toBe(entries[0].hash);
+  });
+
+  test('first entry prevHash is genesis hash', () => {
+    var trail = createLabAuditTrail();
+    trail.recordEvent(mkEvent('print_start', 'A'));
+    expect(trail.getEntries()[0].prevHash).toBe('00000000');
+  });
+
+  test('custom genesis hash is used', () => {
+    var trail = createLabAuditTrail({ genesisHash: 'deadbeef' });
+    trail.recordEvent(mkEvent('print_start', 'A'));
+    expect(trail.getEntries()[0].prevHash).toBe('deadbeef');
+  });
+
+  test('hashes are deterministic', () => {
+    var t1 = createLabAuditTrail();
+    var t2 = createLabAuditTrail();
+    var ts = '2025-01-01T00:00:00Z';
+    t1.recordEvent({ type: 'print_start', operator: 'A', timestamp: ts, data: {} });
+    t2.recordEvent({ type: 'print_start', operator: 'A', timestamp: ts, data: {} });
+    expect(t1.getEntries()[0].hash).toBe(t2.getEntries()[0].hash);
+  });
+});
+
+describe('verifyIntegrity', () => {
+  test('returns intact for empty trail', () => {
+    var trail = createLabAuditTrail();
+    var result = trail.verifyIntegrity();
+    expect(result.intact).toBe(true);
+    expect(result.entries).toBe(0);
+  });
+
+  test('returns intact for valid chain', () => {
+    var trail = seedTrail(10);
+    var result = trail.verifyIntegrity();
+    expect(result.intact).toBe(true);
+    expect(result.entries).toBe(10);
+    expect(result.errors).toEqual([]);
+  });
+
+  test('detects hash tampering', () => {
+    var trail = seedTrail(5);
+    trail.getEntries()[2].hash = 'ffffffff';
+    var result = trail.verifyIntegrity();
+    expect(result.intact).toBe(false);
+    expect(result.errors.some(function(e) { return e.issue === 'hash_mismatch'; })).toBe(true);
+  });
+
+  test('detects chain break', () => {
+    var trail = seedTrail(5);
+    trail.getEntries()[3].prevHash = 'aaaaaaaa';
+    var result = trail.verifyIntegrity();
+    expect(result.intact).toBe(false);
+    expect(result.errors.some(function(e) { return e.issue === 'broken_chain'; })).toBe(true);
+  });
+});
+
+describe('getEntries (filtering)', () => {
+  test('filter by type', () => {
+    var trail = seedTrail(10);
+    var results = trail.getEntries({ type: 'calibration' });
+    results.forEach(function(e) { expect(e.type).toBe('calibration'); });
+    expect(results.length).toBeGreaterThan(0);
+  });
+
+  test('filter by category', () => {
+    var trail = seedTrail(10);
+    var results = trail.getEntries({ category: 'print' });
+    results.forEach(function(e) { expect(e.category).toBe('print'); });
+  });
+
+  test('filter by severity', () => {
+    var trail = createLabAuditTrail();
+    trail.recordEvent(mkEvent('print_error', 'A'));
+    trail.recordEvent(mkEvent('print_start', 'A'));
+    var critical = trail.getEntries({ severity: 'critical' });
+    expect(critical.length).toBe(1);
+    expect(critical[0].type).toBe('print_error');
+  });
+
+  test('filter by operator (case-insensitive)', () => {
+    var trail = seedTrail(10);
+    var results = trail.getEntries({ operator: 'dr. chen' });
+    results.forEach(function(e) { expect(e.operator).toBe('Dr. Chen'); });
+  });
+
+  test('filter by date range', () => {
+    var trail = createLabAuditTrail();
+    var now = Date.now();
+    trail.recordEvent({ type: 'print_start', operator: 'A', timestamp: new Date(now - 5 * 3600000).toISOString() });
+    trail.recordEvent({ type: 'calibration', operator: 'A', timestamp: new Date(now - 2 * 3600000).toISOString() });
+    trail.recordEvent({ type: 'env_reading', operator: 'A', timestamp: new Date(now).toISOString() });
+    var results = trail.getEntries({ from: new Date(now - 3 * 3600000).toISOString(), to: new Date(now + 1000).toISOString() });
+    expect(results.length).toBe(2);
+  });
+
+  test('filter by search term', () => {
+    var trail = createLabAuditTrail();
+    trail.recordEvent({ type: 'operator_note', operator: 'A', notes: 'checked nozzle pressure' });
+    trail.recordEvent(mkEvent('print_start', 'A'));
+    var results = trail.getEntries({ search: 'nozzle' });
+    expect(results.length).toBe(1);
+  });
+
+  test('limit returns last N entries', () => {
+    var trail = seedTrail(20);
+    var results = trail.getEntries({ limit: 5 });
+    expect(results.length).toBe(5);
+    expect(results[results.length - 1].id).toBe(20);
+  });
+});
+
+describe('getEntry', () => {
+  test('returns entry by ID', () => {
+    var trail = seedTrail(5);
+    var entry = trail.getEntry(3);
+    expect(entry).not.toBeNull();
+    expect(entry.id).toBe(3);
+  });
+
+  test('returns null for unknown ID', () => {
+    var trail = seedTrail(5);
+    expect(trail.getEntry(99)).toBeNull();
+  });
+});
+
+describe('getStatistics', () => {
+  test('returns category and severity counts', () => {
+    var trail = seedTrail(10);
+    var stats = trail.getStatistics();
+    expect(stats.totalEvents).toBe(10);
+    expect(stats.bySeverity.info).toBeGreaterThan(0);
+  });
+
+  test('identifies top operator', () => {
+    var trail = createLabAuditTrail();
+    trail.recordEvent(mkEvent('print_start', 'Alice'));
+    trail.recordEvent(mkEvent('print_start', 'Bob'));
+    trail.recordEvent(mkEvent('print_start', 'Bob'));
+    var stats = trail.getStatistics();
+    expect(stats.topOperator).toBe('Bob');
+    expect(stats.uniqueOperators).toBe(2);
+  });
+
+  test('tracks peak hour', () => {
+    var trail = createLabAuditTrail();
+    var peakDate = new Date(2026, 2, 9, 14, 0, 0);
+    for (var i = 0; i < 5; i++) {
+      trail.recordEvent({ type: 'print_start', operator: 'A', timestamp: new Date(peakDate.getTime() + i * 60000).toISOString() });
+    }
+    trail.recordEvent({ type: 'print_start', operator: 'A', timestamp: new Date(2026, 2, 9, 9, 0, 0).toISOString() });
+    expect(trail.getStatistics().peakHour).toBe(14);
+  });
+});
+
+describe('getOperatorActivity', () => {
+  test('returns null for unknown operator', () => {
+    var trail = seedTrail(5);
+    expect(trail.getOperatorActivity('nobody')).toBeNull();
+  });
+
+  test('returns activity summary', () => {
+    var trail = seedTrail(10);
+    var activity = trail.getOperatorActivity('Dr. Chen');
+    expect(activity).not.toBeNull();
+    expect(activity.totalEvents).toBeGreaterThan(0);
+  });
+
+  test('counts critical and warning events', () => {
+    var trail = createLabAuditTrail();
+    trail.recordEvent(mkEvent('print_start', 'Alice'));
+    trail.recordEvent(mkEvent('print_error', 'Alice'));
+    trail.recordEvent(mkEvent('env_alert', 'Alice'));
+    var activity = trail.getOperatorActivity('Alice');
+    expect(activity.criticalEvents).toBe(1);
+    expect(activity.warningEvents).toBe(1);
+  });
+});
+
+describe('getComplianceReport', () => {
+  test('returns report structure', () => {
+    var trail = seedTrail(10);
+    var report = trail.getComplianceReport();
+    expect(report.chainIntegrity).toBe('intact');
+    expect(typeof report.complianceScore).toBe('number');
+    expect(typeof report.complianceGrade).toBe('string');
+  });
+
+  test('grades A for well-maintained trail', () => {
+    var trail = createLabAuditTrail();
+    var now = new Date();
+    var recent = new Date(now.getTime() - 2 * 3600000).toISOString();
+    ['calibration', 'env_reading', 'quality_check', 'maintenance_done'].forEach(function(t) {
+      trail.recordEvent({ type: t, operator: 'A', timestamp: recent });
+    });
+    for (var d = 0; d < 30; d++) {
+      trail.recordEvent({ type: 'env_reading', operator: 'A', timestamp: new Date(now.getTime() - d * 86400000).toISOString() });
+    }
+    var report = trail.getComplianceReport();
+    expect(report.complianceGrade).toBe('A');
+    expect(report.complianceScore).toBeGreaterThanOrEqual(90);
+  });
+
+  test('detects missing weekly checks', () => {
+    var trail = createLabAuditTrail();
+    trail.recordEvent({ type: 'print_start', operator: 'A', timestamp: new Date(Date.now() - 10 * 86400000).toISOString() });
+    var report = trail.getComplianceReport();
+    expect(report.missingWeeklyChecks).toContain('calibration');
+    expect(report.missingWeeklyChecks).toContain('environmental_reading');
+  });
+
+  test('reports compromised integrity', () => {
+    var trail = seedTrail(5);
+    trail.getEntries()[2].hash = 'deadbeef';
+    var report = trail.getComplianceReport();
+    expect(report.chainIntegrity).toBe('compromised');
+  });
+});
+
+describe('getTimeline', () => {
+  test('groups events by day', () => {
+    var trail = createLabAuditTrail();
+    trail.recordEvent({ type: 'print_start', operator: 'A', timestamp: '2026-01-10T09:00:00Z' });
+    trail.recordEvent({ type: 'print_complete', operator: 'A', timestamp: '2026-01-10T11:00:00Z' });
+    trail.recordEvent({ type: 'calibration', operator: 'A', timestamp: '2026-01-11T08:00:00Z' });
+    var tl = trail.getTimeline();
+    expect(tl.days).toEqual(['2026-01-10', '2026-01-11']);
+    expect(tl.timeline['2026-01-10'].length).toBe(2);
+    expect(tl.totalEvents).toBe(3);
+  });
+
+  test('respects filters', () => {
+    var trail = seedTrail(20);
+    var tl = trail.getTimeline({ category: 'print' });
+    tl.days.forEach(function(d) {
+      tl.timeline[d].forEach(function(e) { expect(e.type).toMatch(/^print_/); });
+    });
+  });
+});
+
+describe('export / import', () => {
+  test('exportJSON includes all fields', () => {
+    var trail = seedTrail(5);
+    var json = trail.exportJSON();
+    expect(json.entries.length).toBe(5);
+    expect(json.integrity.intact).toBe(true);
+    expect(json.genesisHash).toBe('00000000');
+  });
+
+  test('exportCSV has header and correct row count', () => {
+    var trail = seedTrail(5);
+    var lines = trail.exportCSV().trim().split('\n');
+    expect(lines[0]).toContain('ID,Timestamp');
+    expect(lines.length).toBe(6);
+  });
+
+  test('importJSON restores and verifies', () => {
+    var trail = seedTrail(5);
+    var exported = trail.exportJSON();
+    var trail2 = createLabAuditTrail();
+    expect(trail2.importJSON(exported).intact).toBe(true);
+    expect(trail2.getCount()).toBe(5);
+  });
+
+  test('importJSON detects tampered data', () => {
+    var trail = seedTrail(5);
+    var exported = trail.exportJSON();
+    exported.entries[2].hash = 'deadbeef';
+    var trail2 = createLabAuditTrail();
+    expect(trail2.importJSON(exported).intact).toBe(false);
+  });
+
+  test('importJSON rejects non-empty trail', () => {
+    var trail = seedTrail(3);
+    expect(() => trail.importJSON(trail.exportJSON())).toThrow('non-empty');
+  });
+
+  test('importJSON rejects invalid data', () => {
+    var trail = createLabAuditTrail();
+    expect(() => trail.importJSON({})).toThrow('Invalid');
+  });
+});
+
+describe('lock', () => {
+  test('prevents new events', () => {
+    var trail = createLabAuditTrail();
+    trail.recordEvent(mkEvent('print_start', 'A'));
+    trail.lock();
+    expect(trail.isLocked()).toBe(true);
+    expect(() => trail.recordEvent(mkEvent('print_start', 'A'))).toThrow('locked');
+  });
+
+  test('allows reads', () => {
+    var trail = seedTrail(5);
+    trail.lock();
+    expect(trail.getCount()).toBe(5);
+    expect(trail.verifyIntegrity().intact).toBe(true);
+  });
+});
+
+describe('purgeExpired', () => {
+  test('purges old entries', () => {
+    var trail = createLabAuditTrail({ retentionDays: 7 });
+    trail.recordEvent({ type: 'print_start', operator: 'A', timestamp: new Date(Date.now() - 10 * 86400000).toISOString() });
+    trail.recordEvent({ type: 'print_start', operator: 'A', timestamp: new Date().toISOString() });
+    var result = trail.purgeExpired();
+    expect(result.purged).toBe(1);
+    expect(result.remaining).toBe(1);
+  });
+
+  test('keeps recent entries', () => {
+    var trail = createLabAuditTrail({ retentionDays: 365 });
+    var now = Date.now();
+    for (var i = 0; i < 5; i++) trail.recordEvent({ type: 'print_start', operator: 'A', timestamp: new Date(now - i * 86400000).toISOString() });
+    expect(trail.purgeExpired().remaining).toBe(5);
+  });
+});
+
+describe('maxEntries', () => {
+  test('enforces limit', () => {
+    var trail = createLabAuditTrail({ maxEntries: 5 });
+    for (var i = 0; i < 8; i++) trail.recordEvent(mkEvent('print_start', 'A'));
+    expect(trail.getCount()).toBe(5);
+  });
+});
+
+describe('all event types', () => {
+  test('every EVENT_TYPE can be recorded', () => {
+    var trail = createLabAuditTrail();
+    Object.keys(trail.EVENT_TYPES).forEach(function(type) {
+      expect(function() { trail.recordEvent({ type: type, operator: 'Tester' }); }).not.toThrow();
+    });
+    expect(trail.getCount()).toBe(Object.keys(trail.EVENT_TYPES).length);
+  });
+});


### PR DESCRIPTION
Adds createLabAuditTrail() module for GLP/GMP-compliant lab event logging. FNV-1a hash-chained entries across 29 event types (9 categories, 3 severities). Features: integrity verification, compliance grading (A-F), rich filtering, timeline views, operator activity tracking, JSON/CSV export+import, lock/archive, retention purging. 54 tests.