### PR TITLE
fix: guard against division by zero in getViabilityTrend

### DIFF
--- a/__tests__/passage.test.js
+++ b/__tests__/passage.test.js
@@ -222,6 +222,21 @@ describe('Cell Passage Tracker', function () {
             var trend = tracker.getViabilityTrend('V');
             expect(trend.trend).toBe('improving');
         });
+
+        test('handles identical passage numbers without NaN (fixes #45)', function () {
+            tracker.addCellLine({ id: 'V' });
+            tracker.recordPassage('V', { passage: 5, viability: 90 });
+            tracker.recordPassage('V', { passage: 5, viability: 85 });
+            tracker.recordPassage('V', { passage: 5, viability: 88 });
+            var trend = tracker.getViabilityTrend('V');
+            expect(trend.trend).toBe('insufficient_data');
+            expect(trend.reason).toBe('all_same_passage');
+            expect(trend.slope).toBe(0);
+            expect(isNaN(trend.slope)).toBe(false);
+            expect(isNaN(trend.intercept)).toBe(false);
+            expect(trend.currentViability).toBe(88);
+            expect(trend.projectedLimitPassage).toBeNull();
+        });
     });
 
     describe('getConfluenceProfile', function () {

--- a/docs/shared/passage.js
+++ b/docs/shared/passage.js
@@ -127,7 +127,20 @@ function createPassageTracker() {
             sumXY += p.passage * p.viability;
             sumXX += p.passage * p.passage;
         });
-        var slope = (n * sumXY - sumX * sumY) / (n * sumXX - sumX * sumX);
+        var denominator = n * sumXX - sumX * sumX;
+        if (denominator === 0) {
+            return {
+                trend: 'insufficient_data',
+                points: n,
+                slope: 0,
+                intercept: 0,
+                currentViability: ps[ps.length - 1].viability,
+                projectedLimitPassage: null,
+                reason: 'all_same_passage',
+                recommendation: 'Record passages at different passage numbers for trend analysis'
+            };
+        }
+        var slope = (n * sumXY - sumX * sumY) / denominator;
         var intercept = (sumY - slope * sumX) / n;
 
         var trend = 'stable';


### PR DESCRIPTION
Fixes #45

When all recorded passages have identical passage numbers, the linear regression denominator evaluates to zero, producing \NaN\ for slope/intercept. This silently corrupts downstream analysis in \getOptimalPassageWindow\, \getSenescenceRisk\, \getCellLineReport\, and \getFleetReport\.

**Fix:** Added denominator guard before division. Returns clean \insufficient_data\ result with \eason: 'all_same_passage'\ instead of \NaN\.

**Test added:** Verifies identical-passage scenario returns valid (non-NaN) results with correct fields.

52 passage tests passing.