### PR TITLE
feat: Add process capability module (Cp/Cpk/Pp/Ppk, Six Sigma)

### DIFF
--- a/__tests__/shared/capability.test.js
+++ b/__tests__/shared/capability.test.js
@@ -1,0 +1,145 @@
+/**
+ * Tests for Process Capability module (Cp, Cpk, Pp, Ppk, Six Sigma).
+ */
+
+'use strict';
+
+var capability = require('../../docs/shared/capability');
+
+describe('createCapabilityAnalyzer', function () {
+    var analyzer;
+
+    beforeEach(function () {
+        analyzer = capability.createCapabilityAnalyzer();
+    });
+
+    describe('input validation', function () {
+        test('throws on missing measurements', function () {
+            expect(function () { analyzer.analyze({ lsl: 1, usl: 3 }); }).toThrow();
+        });
+
+        test('throws on empty measurements', function () {
+            expect(function () { analyzer.analyze({ measurements: [], lsl: 1, usl: 3 }); }).toThrow();
+        });
+
+        test('throws on missing spec limits', function () {
+            expect(function () { analyzer.analyze({ measurements: [1, 2, 3] }); }).toThrow();
+        });
+
+        test('throws when lsl >= usl', function () {
+            expect(function () { analyzer.analyze({ measurements: [1, 2], lsl: 3, usl: 1 }); }).toThrow();
+        });
+
+        test('throws with fewer than 2 measurements', function () {
+            expect(function () { analyzer.analyze({ measurements: [2], lsl: 1, usl: 3 }); }).toThrow();
+        });
+    });
+
+    describe('flat measurements (no subgroups)', function () {
+        test('centered process with low variation is capable', function () {
+            // Tight measurements around 2.25 with spec [1.5, 3.0]
+            var data = [2.2, 2.25, 2.3, 2.2, 2.25, 2.3, 2.22, 2.28, 2.24, 2.26];
+            var result = analyzer.analyze({ measurements: data, lsl: 1.5, usl: 3.0 });
+
+            expect(result.verdict).toBe('capable');
+            expect(result.cp).toBeGreaterThan(1.33);
+            expect(result.cpk).toBeGreaterThan(1.33);
+            expect(result.pp).toBeGreaterThan(1.33);
+            expect(result.ppk).toBeGreaterThan(1.33);
+            expect(result.n).toBe(10);
+            expect(result.pctOutOfSpec).toBeLessThan(0.01);
+        });
+
+        test('wide variation yields incapable', function () {
+            var data = [1.0, 3.5, 0.5, 3.8, 1.2, 3.0, 0.8, 3.2];
+            var result = analyzer.analyze({ measurements: data, lsl: 1.5, usl: 3.0 });
+
+            expect(result.verdict).toBe('incapable');
+            expect(result.cpk).toBeLessThan(1.0);
+        });
+
+        test('off-center process has cpk < cp', function () {
+            // Measurements clustered near upper spec limit
+            var data = [2.8, 2.85, 2.9, 2.82, 2.88, 2.87, 2.83, 2.86];
+            var result = analyzer.analyze({ measurements: data, lsl: 1.5, usl: 3.0 });
+
+            expect(result.cp).toBeGreaterThan(result.cpk);
+        });
+
+        test('default target is midpoint', function () {
+            var result = analyzer.analyze({ measurements: [2.0, 2.5], lsl: 1.0, usl: 3.0 });
+            expect(result.target).toBe(2.0);
+        });
+
+        test('custom target is preserved', function () {
+            var result = analyzer.analyze({ measurements: [2.0, 2.5], lsl: 1.0, usl: 3.0, target: 1.8 });
+            expect(result.target).toBe(1.8);
+        });
+    });
+
+    describe('grouped measurements (batches)', function () {
+        test('within-group sigma differs from overall sigma', function () {
+            // Three batches with different means but tight within-batch variation
+            var batches = [
+                [2.0, 2.01, 2.02],
+                [2.3, 2.31, 2.32],
+                [2.1, 2.11, 2.12]
+            ];
+            var result = analyzer.analyze({ measurements: batches, lsl: 1.5, usl: 3.0 });
+
+            // Within-batch sigma should be much smaller than overall
+            expect(result.sigmaWithin).toBeLessThan(result.sigmaOverall);
+            // Cp (short-term) should be better than Pp (long-term)
+            expect(result.cp).toBeGreaterThan(result.pp);
+            expect(result.n).toBe(9);
+        });
+
+        test('consistent batches have similar Cp and Pp', function () {
+            // Batches with same mean and same spread
+            var batches = [
+                [2.2, 2.25, 2.3],
+                [2.2, 2.25, 2.3],
+                [2.2, 2.25, 2.3]
+            ];
+            var result = analyzer.analyze({ measurements: batches, lsl: 1.5, usl: 3.0 });
+
+            expect(result.verdict).toBe('capable');
+        });
+    });
+
+    describe('sigma level and pctOutOfSpec', function () {
+        test('sigma level equals 3 * cpk', function () {
+            var data = [2.0, 2.1, 2.2, 2.15, 2.05, 2.12];
+            var result = analyzer.analyze({ measurements: data, lsl: 1.5, usl: 3.0 });
+
+            expect(result.sigmaLevel).toBeCloseTo(3 * result.cpk, 3);
+        });
+
+        test('pctOutOfSpec is between 0 and 1', function () {
+            var data = [2.0, 2.1, 2.2, 2.15, 2.05];
+            var result = analyzer.analyze({ measurements: data, lsl: 1.5, usl: 3.0 });
+
+            expect(result.pctOutOfSpec).toBeGreaterThanOrEqual(0);
+            expect(result.pctOutOfSpec).toBeLessThanOrEqual(1);
+        });
+    });
+
+    describe('output shape', function () {
+        test('returns all expected fields', function () {
+            var result = analyzer.analyze({ measurements: [2.0, 2.5, 2.3], lsl: 1.0, usl: 3.0 });
+            var keys = Object.keys(result);
+
+            expect(keys).toContain('cp');
+            expect(keys).toContain('cpk');
+            expect(keys).toContain('pp');
+            expect(keys).toContain('ppk');
+            expect(keys).toContain('sigmaLevel');
+            expect(keys).toContain('pctOutOfSpec');
+            expect(keys).toContain('verdict');
+            expect(keys).toContain('n');
+            expect(keys).toContain('mean');
+            expect(keys).toContain('sigmaWithin');
+            expect(keys).toContain('sigmaOverall');
+        });
+    });
+});

--- a/docs/shared/capability.js
+++ b/docs/shared/capability.js
@@ -1,0 +1,228 @@
+/**
+ * BioBots Process Capability Module
+ *
+ * Computes Six Sigma process capability indices (Cp, Cpk, Pp, Ppk),
+ * sigma level, predicted % out of spec, and a capability verdict.
+ *
+ * Supports both flat measurement arrays and grouped (batch) data for
+ * distinguishing within-batch (short-term) vs batch-to-batch (long-term) variation.
+ *
+ * @example
+ *   var capability = require('./capability');
+ *   var analyzer = capability.createCapabilityAnalyzer();
+ *   var result = analyzer.analyze({
+ *     measurements: [[2.1, 2.3, 2.2], [2.0, 2.4, 2.1]],
+ *     lsl: 1.5,
+ *     usl: 3.0,
+ *     target: 2.25
+ *   });
+ */
+
+'use strict';
+
+/* ------------------------------------------------------------------ */
+/*  Helper: standard normal CDF (Abramowitz & Stegun approximation)   */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Approximate the standard normal cumulative distribution function.
+ * Max absolute error ≈ 7.5 × 10⁻⁸.
+ * @param {number} x
+ * @returns {number}
+ */
+function normalCDF(x) {
+    if (x === Infinity) return 1;
+    if (x === -Infinity) return 0;
+    var sign = x < 0 ? -1 : 1;
+    x = Math.abs(x);
+    var t = 1.0 / (1.0 + 0.2316419 * x);
+    var d = 0.3989422804014327; // 1 / sqrt(2π)
+    var p = d * Math.exp(-0.5 * x * x) *
+        (t * (0.319381530 +
+            t * (-0.356563782 +
+                t * (1.781477937 +
+                    t * (-1.821255978 +
+                        t * 1.330274429)))));
+    return sign < 0 ? p : 1 - p;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Statistics helpers                                                 */
+/* ------------------------------------------------------------------ */
+
+function mean(arr) {
+    if (!arr.length) return 0;
+    var sum = 0;
+    for (var i = 0; i < arr.length; i++) sum += arr[i];
+    return sum / arr.length;
+}
+
+function stdev(arr, ddof) {
+    if (arr.length < 2) return 0;
+    ddof = ddof == null ? 1 : ddof;
+    var m = mean(arr);
+    var ss = 0;
+    for (var i = 0; i < arr.length; i++) ss += (arr[i] - m) * (arr[i] - m);
+    return Math.sqrt(ss / (arr.length - ddof));
+}
+
+/**
+ * Pooled within-subgroup standard deviation using the average-range method.
+ * Uses d2 unbiasing constants for subgroup sizes 2-10.
+ * @param {number[][]} groups
+ * @returns {number}
+ */
+function pooledWithinSigma(groups) {
+    // d2 constants for subgroup sizes 2–10
+    var d2 = { 2: 1.128, 3: 1.693, 4: 2.059, 5: 2.326, 6: 2.534, 7: 2.704, 8: 2.847, 9: 2.970, 10: 3.078 };
+
+    var totalRange = 0;
+    var count = 0;
+    for (var i = 0; i < groups.length; i++) {
+        var g = groups[i];
+        if (g.length < 2) continue;
+        var min = g[0], max = g[0];
+        for (var j = 1; j < g.length; j++) {
+            if (g[j] < min) min = g[j];
+            if (g[j] > max) max = g[j];
+        }
+        totalRange += (max - min);
+        count++;
+    }
+    if (count === 0) return 0;
+
+    var avgRange = totalRange / count;
+    var n = groups[0].length;
+    var d2Val = d2[Math.min(n, 10)] || d2[10];
+    return avgRange / d2Val;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Main analyzer                                                      */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Create a process capability analyzer.
+ * @returns {{ analyze: function }}
+ */
+function createCapabilityAnalyzer() {
+    return { analyze: analyze };
+}
+
+/**
+ * Analyze process capability.
+ *
+ * @param {Object} opts
+ * @param {number[]|number[][]} opts.measurements - Flat array or array of batch arrays.
+ * @param {number} opts.lsl - Lower specification limit.
+ * @param {number} opts.usl - Upper specification limit.
+ * @param {number} [opts.target] - Target value (defaults to midpoint of LSL/USL).
+ * @returns {Object} Capability results.
+ */
+function analyze(opts) {
+    if (!opts || !opts.measurements || !opts.measurements.length) {
+        throw new Error('measurements array is required and must not be empty');
+    }
+    if (opts.lsl == null || opts.usl == null) {
+        throw new Error('Both lsl and usl are required');
+    }
+    if (opts.lsl >= opts.usl) {
+        throw new Error('lsl must be less than usl');
+    }
+
+    var lsl = opts.lsl;
+    var usl = opts.usl;
+    var target = opts.target != null ? opts.target : (lsl + usl) / 2;
+
+    // Determine if data is grouped (batches) or flat
+    var isGrouped = Array.isArray(opts.measurements[0]);
+    var allValues = [];
+    var groups = null;
+
+    if (isGrouped) {
+        groups = opts.measurements;
+        for (var i = 0; i < groups.length; i++) {
+            for (var j = 0; j < groups[i].length; j++) {
+                allValues.push(groups[i][j]);
+            }
+        }
+    } else {
+        allValues = opts.measurements;
+    }
+
+    if (allValues.length < 2) {
+        throw new Error('At least 2 measurements are required');
+    }
+
+    var xbar = mean(allValues);
+    var specWidth = usl - lsl;
+
+    // Overall (long-term) standard deviation — sample stdev
+    var sigmaOverall = stdev(allValues, 1);
+
+    // Within-subgroup (short-term) standard deviation
+    var sigmaWithin;
+    if (groups && groups.length >= 2) {
+        sigmaWithin = pooledWithinSigma(groups);
+        if (sigmaWithin === 0) sigmaWithin = sigmaOverall; // fallback
+    } else {
+        // No subgroups — short-term ≈ long-term
+        sigmaWithin = sigmaOverall;
+    }
+
+    // Cp / Cpk (short-term, within-subgroup variation)
+    var cp = sigmaWithin > 0 ? specWidth / (6 * sigmaWithin) : Infinity;
+    var cpupper = sigmaWithin > 0 ? (usl - xbar) / (3 * sigmaWithin) : Infinity;
+    var cplower = sigmaWithin > 0 ? (xbar - lsl) / (3 * sigmaWithin) : Infinity;
+    var cpk = Math.min(cpupper, cplower);
+
+    // Pp / Ppk (long-term, overall variation)
+    var pp = sigmaOverall > 0 ? specWidth / (6 * sigmaOverall) : Infinity;
+    var ppupper = sigmaOverall > 0 ? (usl - xbar) / (3 * sigmaOverall) : Infinity;
+    var pplower = sigmaOverall > 0 ? (xbar - lsl) / (3 * sigmaOverall) : Infinity;
+    var ppk = Math.min(ppupper, pplower);
+
+    // Sigma level (based on Cpk)
+    var sigmaLevel = 3 * cpk;
+
+    // Predicted % out of spec (using overall sigma for realistic prediction)
+    var zUpper = sigmaOverall > 0 ? (usl - xbar) / sigmaOverall : Infinity;
+    var zLower = sigmaOverall > 0 ? (xbar - lsl) / sigmaOverall : Infinity;
+    var pctOutOfSpec = (1 - normalCDF(zUpper)) + (1 - normalCDF(zLower));
+
+    // Verdict
+    var verdict;
+    if (cpk >= 1.33) {
+        verdict = 'capable';
+    } else if (cpk >= 1.0) {
+        verdict = 'marginal';
+    } else {
+        verdict = 'incapable';
+    }
+
+    return {
+        cp: round4(cp),
+        cpk: round4(cpk),
+        pp: round4(pp),
+        ppk: round4(ppk),
+        sigmaLevel: round4(sigmaLevel),
+        pctOutOfSpec: round4(pctOutOfSpec),
+        verdict: verdict,
+        n: allValues.length,
+        mean: round4(xbar),
+        sigmaWithin: round4(sigmaWithin),
+        sigmaOverall: round4(sigmaOverall),
+        lsl: lsl,
+        usl: usl,
+        target: target
+    };
+}
+
+function round4(v) {
+    if (!isFinite(v)) return v;
+    return Math.round(v * 10000) / 10000;
+}
+
+module.exports = {
+    createCapabilityAnalyzer: createCapabilityAnalyzer
+};

--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ var passage = require('./docs/shared/passage');
 var mixer = require('./docs/shared/mixer');
 var jobEstimator = require('./docs/shared/jobEstimator');
 var scaffold = require('./docs/shared/scaffold');
+var capability = require('./docs/shared/capability');
 
 module.exports = {
     createMaterialCalculator: calculator.createMaterialCalculator,
@@ -39,5 +40,6 @@ module.exports = {
     createPassageTracker: passage.createPassageTracker,
     createBioinkMixer: mixer.createBioinkMixer,
     createJobEstimator: jobEstimator.createJobEstimator,
-    createScaffoldCalculator: scaffold.createScaffoldCalculator
+    createScaffoldCalculator: scaffold.createScaffoldCalculator,
+    createCapabilityAnalyzer: capability.createCapabilityAnalyzer
 };


### PR DESCRIPTION
Implements process capability scoring as proposed in #61. Adds Cp/Cpk/Pp/Ppk, sigma level, pct out of spec, and capability verdict. 15 tests. Closes #61