### PR TITLE
refactor: centralize deep-clone with structuredClone support

### DIFF
--- a/docs/shared/labSafetyChecklist.js
+++ b/docs/shared/labSafetyChecklist.js
@@ -142,8 +142,10 @@ function isoNow() {
     return new Date().toISOString();
 }
 
+var deepClone = require('./sanitize').deepClone;
+
 function cloneDeep(obj) {
-    return JSON.parse(JSON.stringify(obj));
+    return deepClone(obj);
 }
 
 /* ------------------------------------------------------------------ */

--- a/docs/shared/mediaPrep.js
+++ b/docs/shared/mediaPrep.js
@@ -22,6 +22,7 @@
 'use strict';
 
 var _stripDangerous = require('./sanitize').stripDangerousKeys;
+var _deepClone = require('./sanitize').deepClone;
 
 var COMMON_MEDIA = {
     DMEM: {
@@ -280,7 +281,7 @@ function createMediaPrepCalculator() {
                 throw new Error('Valid recipe and positive newVolume required');
             }
             var factor = newVolume / recipe.targetVolume;
-            var scaled = JSON.parse(JSON.stringify(recipe));
+            var scaled = _deepClone(recipe);
             scaled.targetVolume = newVolume;
             scaled.baseMediaVolume = Math.round(recipe.baseMediaVolume * factor * 1000) / 1000;
             scaled.totalSupplementVolume = Math.round(recipe.totalSupplementVolume * factor * 1000) / 1000;
@@ -296,7 +297,7 @@ function createMediaPrepCalculator() {
             }
 
             scaled.supplements = recipe.supplements.map(function (s) {
-                var ns = JSON.parse(JSON.stringify(s));
+                var ns = _deepClone(s);
                 if (ns.volumeToAdd) ns.volumeToAdd = Math.round(s.volumeToAdd * factor * 1000) / 1000;
                 if (ns.massToAdd) ns.massToAdd = Math.round(s.massToAdd * factor * 10000) / 10000;
                 return ns;

--- a/docs/shared/protocolTemplates.js
+++ b/docs/shared/protocolTemplates.js
@@ -25,6 +25,7 @@
 /* ------------------------------------------------------------------ */
 
 var _sanitize = require('./sanitize');
+var _deepClone = _sanitize.deepClone;
 var _isDangerousKey = _sanitize.isDangerousKey;
 
 var TEMPLATES = {
@@ -228,7 +229,7 @@ var TEMPLATES = {
 /* ------------------------------------------------------------------ */
 
 function deepClone(obj) {
-    return JSON.parse(JSON.stringify(obj));
+    return _deepClone(obj);
 }
 
 function totalTime(steps) {

--- a/docs/shared/sanitize.js
+++ b/docs/shared/sanitize.js
@@ -101,9 +101,31 @@ function safeResolvePath(obj, path) {
     return current === undefined ? null : current;
 }
 
+/**
+ * Deep-clone a plain JSON-safe object.
+ *
+ * Uses `structuredClone` when available (Node >= 17, modern browsers),
+ * otherwise falls back to `JSON.parse(JSON.stringify())`.
+ *
+ * Prefer this over inline `JSON.parse(JSON.stringify(obj))` to:
+ *   1. Gain the perf benefit of `structuredClone` (avoids serialization)
+ *   2. Centralize the fallback so it can be swapped once if needed
+ *   3. Clearly communicate intent at call sites
+ *
+ * @param {*} obj - Value to clone (must be JSON-safe for the fallback).
+ * @returns {*} Deep copy.
+ */
+function deepClone(obj) {
+    if (typeof structuredClone === 'function') {
+        return structuredClone(obj);
+    }
+    return JSON.parse(JSON.stringify(obj));
+}
+
 module.exports = {
     DANGEROUS_KEYS: DANGEROUS_KEYS,
     stripDangerousKeys: stripDangerousKeys,
     isDangerousKey: isDangerousKey,
-    safeResolvePath: safeResolvePath
+    safeResolvePath: safeResolvePath,
+    deepClone: deepClone
 };


### PR DESCRIPTION
Replaces scattered JSON.parse(JSON.stringify()) with shared deepClone() helper. Uses structuredClone when available. All tests pass.